### PR TITLE
Correctly set a components display name

### DIFF
--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -14,10 +14,8 @@ import {
  *
  * (desc?: reactDesc | specDesc): stamp
  */
-function createStamp (desc = {}) {
-  const specDesc = parseDesc(desc);
-
-  const stamp = (options, ...args) => {
+function createStamp (specDesc = {}) {
+  const Component = (options, ...args) => {
     let instance = Object.create(specDesc.methods || {});
 
     merge(instance, specDesc.deepProperties);
@@ -27,7 +25,7 @@ function createStamp (desc = {}) {
     if (specDesc.initializers) {
       specDesc.initializers.forEach(initializer => {
         const result = initializer.call(instance, options,
-          { instance, stamp, args: [options].concat(args) });
+          { instance, stamp: Component, args: [options].concat(args) });
         if (isObject(result)) instance = result;
       });
     }
@@ -35,11 +33,13 @@ function createStamp (desc = {}) {
     return instance;
   };
 
-  merge(stamp, specDesc.deepStaticProperties);
-  assign(stamp, specDesc.staticProperties);
-  Object.defineProperties(stamp, specDesc.staticPropertyDescriptors || {});
+  merge(Component, specDesc.deepStaticProperties);
+  assign(Component, specDesc.staticProperties);
+  Object.defineProperties(Component, specDesc.staticPropertyDescriptors || {});
 
-  return stamp;
+  if (!Component.displayName) Component.displayName = 'Component';
+
+  return Component;
 }
 
 /**

--- a/src/utils/descriptor.js
+++ b/src/utils/descriptor.js
@@ -35,11 +35,11 @@ export default function parseDesc (desc = {}) {
   } = desc;
   const parsedDesc = {};
 
-  !displayName && (displayName = 'ReactStamp');
+  displayName && (parsedDesc.staticProperties = { displayName });
   init && (parsedDesc.initializers = [ init ]);
   state && (parsedDesc.deepProperties = { state });
   methods && (parsedDesc.methods = methods);
-  parsedDesc.deepStaticProperties = { ...statics, displayName };
+  parsedDesc.deepStaticProperties = { ...statics };
 
   forEach({ contextTypes, childContextTypes, propTypes, defaultProps },
     (val, key) => val && (parsedDesc.deepStaticProperties[key] = val)

--- a/test/compose.js
+++ b/test/compose.js
@@ -2,7 +2,7 @@ import test from 'tape';
 
 import { compose } from '../src/utils';
 
-test('stamp composed of objects with state', (t) => {
+test('composing objects with state', (t) => {
   t.plan(1);
 
   const obj1 = {
@@ -26,7 +26,7 @@ test('stamp composed of objects with state', (t) => {
   );
 });
 
-test('stamps composed of objects with React statics', (t) => {
+test('composing objects with React statics', (t) => {
   t.plan(4);
 
   const obj1 = {
@@ -86,7 +86,7 @@ test('stamps composed of objects with React statics', (t) => {
   );
 });
 
-test('stamps composed of objects with non-React statics', (t) => {
+test('composing objects with non-React statics', (t) => {
   t.plan(2);
 
   const obj1 = {
@@ -125,7 +125,7 @@ test('stamps composed of objects with non-React statics', (t) => {
   );
 });
 
-test('stamps composed of stamps with methods', (t) => {
+test('composing objects with methods', (t) => {
   t.plan(4);
 
   const obj1 = {
@@ -197,5 +197,32 @@ test('stamps composed of stamps with methods', (t) => {
   t.ok(
     instance.render(),
     'should override `override` methods'
+  );
+});
+
+test('compose', (t) => {
+  t.plan(3);
+
+  const obj1 = {
+    displayName: 'obj1',
+  };
+
+  const obj2 = {
+    displayName: 'obj2',
+  };
+
+  t.equal(
+    compose(obj1, {}).displayName, obj1.displayName,
+    'should ignore undefined `displayName` prop'
+  );
+
+  t.equal(
+    compose(obj1, obj2).displayName, obj2.displayName,
+    'should override defined `displayName` props'
+  );
+
+  t.equal(
+    compose({}).displayName, 'Component',
+    'should set undefined `displayName` prop to \'Component\''
   );
 });


### PR DESCRIPTION
Do not merge, I need to write tests.

The current composition logic will always override the `displayName` prop, even when `displayName` is undefined and gets set to the default value, 'ReactStamp'. `displayName` should override only  when it has been explicitly defined in the object.

I also changed the default value from 'ReactStamp' to 'Component'.